### PR TITLE
Rix1/add framer motion

### DIFF
--- a/components/FooterLink.js
+++ b/components/FooterLink.js
@@ -1,6 +1,9 @@
+import { motion } from "framer-motion";
+import { fadeInUp } from "../lib/animations";
+
 const FooterLink = ({ children, href }) => {
   return (
-    <div className="flex-initial mb-4 mr-3">
+    <motion.div variants={fadeInUp} className="flex-initial mb-4 mr-3">
       <a
         className="bg-white bg-opacity-10 rounded px-3 py-1 text-opacity-80 text-white hover:text-opacity-100 cursor-pointer"
         rel="nofollow noopener"
@@ -9,7 +12,7 @@ const FooterLink = ({ children, href }) => {
       >
         {children}
       </a>
-    </div>
+    </motion.div>
   );
 };
 

--- a/lib/animations.js
+++ b/lib/animations.js
@@ -1,0 +1,41 @@
+export const easing = [0.6, -0.05, 0.01, 0.99];
+
+export const stagger = {
+  animate: {
+    transition: {
+      staggerChildren: 0.1,
+    },
+  },
+};
+
+export const fadeInUp = {
+  initial: {
+    y: 60,
+    opacity: 0,
+    transition: { duration: 0.6, ease: easing },
+  },
+  animate: {
+    y: 0,
+    opacity: 1,
+    transition: {
+      duration: 0.6,
+      ease: easing,
+    },
+  },
+};
+
+export const slideIn = {
+  initial: {
+    x: -40,
+    opacity: 0,
+    transition: { duration: 0.6, ease: easing },
+  },
+  animate: {
+    x: 0,
+    opacity: 1,
+    transition: {
+      duration: 0.6,
+      ease: easing,
+    },
+  },
+};

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  webpack: (config, { dev, isServer }) => {
+    // Replace React with Preact only in client production build
+    if (!dev && !isServer) {
+      Object.assign(config.resolve.alias, {
+        react: "preact/compat",
+        "react-dom/test-utils": "preact/test-utils",
+        "react-dom": "preact/compat",
+      });
+    }
+
+    return config;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "autoprefixer": "^10.2.4",
     "next": "^10.0.6",
     "postcss": "^8.2.5",
+    "preact": "^10.5.12",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "tailwindcss": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "autoprefixer": "^10.2.4",
+    "framer-motion": "^3.3.0",
     "next": "^10.0.6",
     "postcss": "^8.2.5",
     "preact": "^10.5.12",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,40 +1,50 @@
+import { motion } from "framer-motion";
+
 import AppleLogo from "../components/AppleLogo";
 import FooterLink from "../components/FooterLink";
+import { stagger, slideIn } from "../lib/animations";
 
 const HomePage = () => {
   return (
-    <div className="flex w-full min-h-screen justify-center flex-col px-4 sm:px-10 py-10 font-light">
-      <div className="flex mb-6">
-        <img
-          className="flex-initial w-11 h-11"
-          alt="Plug logo – a pink heart filled with a music equalizer"
-          src="/images/logo.png"
-          width="40px"
-          height="40px"
-        />
-        <h1 className="text-4xl ml-2">Plug</h1>
-      </div>
-      <p className="mb-10 text-xl text-white text-opacity-70">
-        Discover and listen to music from{" "}
+    <motion.div
+      initial="initial"
+      animate="animate"
+      variants={stagger}
+      className="flex w-full min-h-screen justify-center flex-col px-4 sm:px-10 py-10 font-light"
+    >
+      <div>
+        <div className="flex mb-6">
+          <img
+            className="flex-initial w-11 h-11"
+            alt="Plug logo – a pink heart filled with a music equalizer"
+            src="/images/logo.png"
+            width="40px"
+            height="40px"
+          />
+          <h1 className="text-4xl ml-2">Plug</h1>
+        </div>
+        <p className="mb-10 text-xl text-white text-opacity-70">
+          Discover and listen to music from{" "}
+          <a
+            className="underline"
+            href="http://hypem.com"
+            rel="nofollow noopener"
+            target="_blank"
+          >
+            Hype Machine
+          </a>
+        </p>
         <a
-          className="underline"
-          href="http://hypem.com"
-          rel="nofollow noopener"
           target="_blank"
+          rel="nofollow noopener"
+          href="https://apps.apple.com/app/plug-for-hype-machine/id1514182074"
+          className="download-button rounded-lg text-black inline-flex px-6 py-4 mr-auto font-normal items-center shadow-md tracking-wide mb-4 cursor-pointer"
         >
-          Hype Machine
+          <AppleLogo />
+          <p className="ml-3">Get it on the App Store</p>
         </a>
-      </p>
-      <a
-        target="_blank"
-        rel="nofollow noopener"
-        href="https://apps.apple.com/app/plug-for-hype-machine/id1514182074"
-        className="download-button rounded-lg text-black flex px-6 py-4 mr-auto font-normal items-center shadow-md tracking-wide mb-4 cursor-pointer"
-      >
-        <AppleLogo />
-        <p className="ml-3">Get it on the App Store</p>
-      </a>
-      <div className="-ml-6 sm:-ml-12">
+      </div>
+      <motion.div variants={slideIn} className="-ml-6 sm:-ml-12">
         <img
           alt="Plug application UI showing two lists of songs from Hypem; popular and favourite"
           src="/images/app.png"
@@ -42,8 +52,13 @@ const HomePage = () => {
           height="565px"
           quality="100"
         />
-      </div>
-      <div className="text-xs tracking-wide flex flex-col sm:flex-row">
+      </motion.div>
+      <motion.div
+        initial="initial"
+        animate="animate"
+        variants={stagger}
+        className="text-xs tracking-wide flex flex-col sm:flex-row"
+      >
         <FooterLink href="http://www.twitter.com/plugformac">
           Follow on Twitter
         </FooterLink>
@@ -53,8 +68,8 @@ const HomePage = () => {
         <FooterLink href="https://github.com/wulkano/Plug/issues/new">
           Submit feedback
         </FooterLink>
-      </div>
-    </div>
+      </motion.div>
+    </motion.div>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,18 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
 "@fullhuman/postcss-purgecss@^3.0.0":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz#47af7b87c9bfb3de4bc94a38f875b928fffdf339"
@@ -1002,6 +1014,24 @@ fraction.js@^4.0.13:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.0.13.tgz#3c1c315fa16b35c85fffa95725a36fa729c69dfe"
   integrity sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==
 
+framer-motion@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-3.3.0.tgz#e355824369f03c8cd07a87ef59b7a8348c33fafd"
+  integrity sha512-bjUrwXfMJZ6D+HSMDiXbMGKmlWGnUux8HotWgORTZkdPTgKAndlRXjeC2ikCgNVo2ifmRvEla5ckP9JaZc7JKA==
+  dependencies:
+    framesync "^5.0.0"
+    hey-listen "^1.0.8"
+    popmotion "^9.1.0"
+    style-value-types "^4.0.1"
+    tslib "^1.10.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@5.0.0, framesync@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-5.0.0.tgz#7de8caedf53ac441118e79680f1beb7391c328b6"
+  integrity sha512-wd8t+JsQGisluSv1twiEeDv0aNGpavGb9q7xgIk9fGbcIWkNXF/KVtrjnOrCwBWJuiXxlJfNkcvGudsI32FxYA==
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
@@ -1123,6 +1153,11 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -1721,6 +1756,16 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popmotion@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.1.0.tgz#4360d06bd18ce8baa8f9284ecec7d55344af6325"
+  integrity sha512-+J7pzzBy5kk2qsP8ilowKs/CH+HoZa3kOGEBNCleCvsPXEF3nKHdfAR3SboMyPvdpIrofaT7ZIy/xWgz446Azw==
+  dependencies:
+    framesync "5.0.0"
+    hey-listen "^1.0.8"
+    style-value-types "^4.0.1"
+    tslib "^1.10.0"
+
 postcss-functions@^3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-functions/-/postcss-functions-3.0.0.tgz#0e94d01444700a481de20de4d55fb2640564250e"
@@ -2289,6 +2334,14 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+style-value-types@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-4.0.1.tgz#23f05dd03e8a850654defc22cf03ebac572aaa00"
+  integrity sha512-aOV/HHyynIyTmU27qfs0oAHhFde6BFIvV4+nMerE2MAPZMwYOeQk1/F3S6djxF2u4HdbiieCPs3ZzWsbNUoc9A==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
+
 styled-jsx@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.3.2.tgz#2474601a26670a6049fb4d3f94bd91695b3ce018"
@@ -2430,6 +2483,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tslib@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,6 +1819,11 @@ postcss@^8.1.6, postcss@^8.2.1, postcss@^8.2.5:
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
+preact@^10.5.12:
+  version "10.5.12"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.12.tgz#6a8ee8bf40a695c505df9abebacd924e4dd37704"
+  integrity sha512-r6siDkuD36oszwlCkcqDJCAKBQxGoeEGytw2DGMD5A/GGdu5Tymw+N2OBXwvOLxg6d1FeY8MgMV3cc5aVQo4Cg==
+
 prebuild-install@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.0.0.tgz#669022bcde57c710a869e39c5ca6bf9cd207f316"


### PR DESCRIPTION
This PR does two things:

- Swap out React with Preact for production builds
- Add `framer-motion` and a few loading animations.

## Demo 🎥

![Kapture 2021-02-07 at 12 44 47](https://user-images.githubusercontent.com/2470775/107145506-5208d280-6942-11eb-8a01-eaa145488b32.gif)


## Experimentation 👨‍🔬 

Framer-motion is a [quite heavy dependency](https://bundlephobia.com/result?p=framer-motion@3.3.0), so I did some experimentation to reduce the initial payload. This approach was inspired by [@leeerob](https://twitter.com/leeerob/)'s ["10 Next.js Tips You Might Not Know"](https://vercel.com/blog/10-next-js-tips-you-might-not-know#tip-5-next.js-with-preact).

Baseline (React and no `framer-motion`) 

```
Page                                                           Size     First Load JS
┌ ○ /                                                          6.87 kB        72.3 kB
├   /_app                                                      0 B            65.4 kB
└ ○ /404                                                       3.46 kB        68.9 kB
+ First Load JS shared by all                                  65.4 kB
  ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.678964.js  14 kB
  ├ chunks/framework.abffcf.js                                 41.8 kB
  ├ chunks/main.4f49a2.js                                      6.48 kB
  ├ chunks/pages/_app.d12d06.js                                2.46 kB
  ├ chunks/webpack.50bee0.js                                   751 B
  └ css/0f0dfd114f863582a461.css                               1.85 kB


```

Swapping out React for Preact: 0.5x of original 💪 
```
Page                                                           Size     First Load JS
┌ ○ /                                                          4.53 kB        35.7 kB
├   /_app                                                      0 B            31.2 kB
└ ○ /404                                                       1.21 kB        32.4 kB
+ First Load JS shared by all                                  31.2 kB
  ├ chunks/commons.99a424.js                                   10.6 kB
  ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.4ef936.js  12.5 kB
  ├ chunks/main.57db02.js                                      6.32 kB
  ├ chunks/pages/_app.b8bd52.js                                1.05 kB
  ├ chunks/webpack.50bee0.js                                   751 B
  └ css/0f0dfd114f863582a461.css                               1.85 kB

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
   (ISR)     incremental static regeneration (uses revalidate in getStaticProps)

✨  Done in 5.84s.
```

Adding `framer-motion` with Preact: Still smaller than baseline! 🙏
```
Page                                                           Size     First Load JS
┌ ○ /                                                          35.4 kB        66.6 kB
├   /_app                                                      0 B            31.2 kB
└ ○ /404                                                       1.21 kB        32.4 kB
+ First Load JS shared by all                                  31.2 kB
  ├ chunks/commons.99a424.js                                   10.6 kB
  ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.4ef936.js  12.5 kB
  ├ chunks/main.12519a.js                                      6.32 kB
  ├ chunks/pages/_app.2b7cf7.js                                1.05 kB
  ├ chunks/webpack.50bee0.js                                   751 B
  └ css/1fc10450c460d253a7ca.css                               1.98 kB

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
   (ISR)     incremental static regeneration (uses revalidate in getStaticProps)

✨  Done in 8.04s.
```

For reference: `framer-motion` together with React 🐘 
```

Page                                                           Size     First Load JS
┌ ○ /                                                          37.7 kB         102 kB
├   /_app                                                      0 B            64.6 kB
└ ○ /404                                                       3.46 kB        68.1 kB
+ First Load JS shared by all                                  64.6 kB
  ├ chunks/f6078781a05fe1bcb0902d23dbbb2662c8d200b3.65ed34.js  13.3 kB
  ├ chunks/framework.abffcf.js                                 41.8 kB
  ├ chunks/main.583c27.js                                      6.32 kB
  ├ chunks/pages/_app.c8da0e.js                                2.46 kB
  ├ chunks/webpack.50bee0.js                                   751 B
  └ css/1fc10450c460d253a7ca.css                               1.98 kB

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
   (ISR)     incremental static regeneration (uses revalidate in getStaticProps)

✨  Done in 8.50s.
```
